### PR TITLE
conda-install libstdcxx-ng to fix pgeof installation issue #102

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -123,6 +123,12 @@ echo
 echo
 echo "⭐ Installing Point Geometric Features"
 echo
+# Install libstdcxx-ng in the conda environment, to make sure pgeof
+# finds its dependencies:
+# https://github.com/drprojects/superpoint_transformer/issues/102
+# This is a linux-only fix:
+# https://stackoverflow.com/a/68845839
+conda install -c conda-forge libstdcxx-ng
 pip install git+https://github.com/drprojects/point_geometric_features.git
 
 echo


### PR DESCRIPTION
change to install.sh script to fix pgeof installation issue